### PR TITLE
Respect Forwarded / X-Forwarded-* headers if present when constructing URLs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Added
 
 * Added ability to configure CORS middleware via JSON configuration file and environment variable, rather than having to modify code.
+* Respect `Forwarded` or `X-Forwarded-*` request headers when building links to better accommodate load balancers and proxies.
 
 ### Changed
 

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -14,7 +14,12 @@ from stac_pydantic.links import Relations
 from stac_pydantic.shared import MimeTypes
 from starlette.requests import Request
 
-from stac_fastapi.pgstac.models.links import CollectionLinks, ItemLinks, PagingLinks
+from stac_fastapi.pgstac.models.links import (
+    CollectionLinks,
+    ItemLinks,
+    PagingLinks,
+    get_base_url_from_request,
+)
 from stac_fastapi.pgstac.types.search import PgstacSearch
 from stac_fastapi.types.core import AsyncBaseCoreClient
 from stac_fastapi.types.errors import InvalidQueryParameter, NotFoundError
@@ -30,7 +35,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
     async def all_collections(self, **kwargs) -> Collections:
         """Read all collections from the database."""
         request: Request = kwargs["request"]
-        base_url = str(request.base_url)
+        base_url = get_base_url_from_request(request)
         pool = request.app.state.readpool
 
         async with pool.acquire() as conn:

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/models/links.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/models/links.py
@@ -76,14 +76,7 @@ def get_base_url_from_request(request: Request) -> str:
         r"([^/])$",
         r"\1/",
         urljoin(
-            "".join(
-                [
-                    proto,
-                    "://",
-                    domain,
-                    port_suffix,
-                ]
-            ),
+            f"{proto}://{domain}{port_suffix}",
             # ensure root path starts with slash
             re.sub(r"^([^/])", r"/\1", request.scope.get("root_path")),
         ),

--- a/stac_fastapi/pgstac/tests/api/test_api.py
+++ b/stac_fastapi/pgstac/tests/api/test_api.py
@@ -408,3 +408,73 @@ async def test_with_existing_cors(app_client):
         )
         == 0
     )
+
+
+@pytest.mark.asyncio
+async def test_search_forwarded_header(
+    load_test_data, app_client, load_test_collection
+):
+    coll = load_test_collection
+    item = load_test_data("test_item.json")
+    await app_client.post(f"/collections/{coll.id}/items", json=item)
+    resp = await app_client.post(
+        "/search",
+        json={
+            "collections": [item["collection"]],
+        },
+        headers={"Forwarded": "proto=https;host=test:1234"},
+    )
+    features = resp.json()["features"]
+    assert len(features) > 0
+    for feature in features:
+        for link in feature["links"]:
+            assert link["href"].startswith("https://test:1234/")
+
+
+@pytest.mark.asyncio
+async def test_search_x_forwarded_headers(
+    load_test_data, app_client, load_test_collection
+):
+    coll = load_test_collection
+    item = load_test_data("test_item.json")
+    await app_client.post(f"/collections/{coll.id}/items", json=item)
+    resp = await app_client.post(
+        "/search",
+        json={
+            "collections": [item["collection"]],
+        },
+        headers={
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Port": "1234",
+        },
+    )
+    features = resp.json()["features"]
+    assert len(features) > 0
+    for feature in features:
+        for link in feature["links"]:
+            assert link["href"].startswith("https://test:1234/")
+
+
+@pytest.mark.asyncio
+async def test_search_duplicate_forward_headers(
+    load_test_data, app_client, load_test_collection
+):
+    coll = load_test_collection
+    item = load_test_data("test_item.json")
+    await app_client.post(f"/collections/{coll.id}/items", json=item)
+    resp = await app_client.post(
+        "/search",
+        json={
+            "collections": [item["collection"]],
+        },
+        headers={
+            "Forwarded": "proto=https;host=test:1234",
+            "X-Forwarded-Proto": "http",
+            "X-Forwarded-Port": "4321",
+        },
+    )
+    features = resp.json()["features"]
+    assert len(features) > 0
+    for feature in features:
+        for link in feature["links"]:
+            assert link["href"].startswith("https://test:1234/")

--- a/stac_fastapi/pgstac/tests/resources/test_collection.py
+++ b/stac_fastapi/pgstac/tests/resources/test_collection.py
@@ -175,3 +175,67 @@ async def test_returns_license_link(app_client, load_test_collection):
     resp_json = resp.json()
     link_rel_types = [link["rel"] for link in resp_json["links"]]
     assert "license" in link_rel_types
+
+
+@pytest.mark.asyncio
+async def test_get_collection_forwarded_header(app_client, load_test_collection):
+    coll = load_test_collection
+    resp = await app_client.get(
+        f"/collections/{coll.id}",
+        headers={"Forwarded": "proto=https;host=test:1234"},
+    )
+    for link in [
+        link
+        for link in resp.json()["links"]
+        if link["rel"] in ["items", "parent", "root", "self"]
+    ]:
+        assert link["href"].startswith("https://test:1234/")
+
+
+@pytest.mark.asyncio
+async def test_get_collection_x_forwarded_headers(app_client, load_test_collection):
+    coll = load_test_collection
+    resp = await app_client.get(
+        f"/collections/{coll.id}",
+        headers={
+            "X-Forwarded-Port": "1234",
+            "X-Forwarded-Proto": "https",
+        },
+    )
+    for link in [
+        link
+        for link in resp.json()["links"]
+        if link["rel"] in ["items", "parent", "root", "self"]
+    ]:
+        assert link["href"].startswith("https://test:1234/")
+
+
+@pytest.mark.asyncio
+async def test_get_collection_duplicate_forwarded_headers(
+    app_client, load_test_collection
+):
+    coll = load_test_collection
+    resp = await app_client.get(
+        f"/collections/{coll.id}",
+        headers={
+            "Forwarded": "proto=https;host=test:1234",
+            "X-Forwarded-Port": "4321",
+            "X-Forwarded-Proto": "http",
+        },
+    )
+    for link in [
+        link
+        for link in resp.json()["links"]
+        if link["rel"] in ["items", "parent", "root", "self"]
+    ]:
+        assert link["href"].startswith("https://test:1234/")
+
+
+@pytest.mark.asyncio
+async def test_get_collections_forwarded_header(app_client, load_test_collection):
+    resp = await app_client.get(
+        "/collections",
+        headers={"Forwarded": "proto=https;host=test:1234"},
+    )
+    for link in resp.json()["links"]:
+        assert link["href"].startswith("https://test:1234/")

--- a/stac_fastapi/pgstac/tests/resources/test_item.py
+++ b/stac_fastapi/pgstac/tests/resources/test_item.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 from datetime import datetime, timedelta
+from http.client import HTTP_PORT
 from typing import Callable
 from urllib.parse import parse_qs, urljoin, urlparse
 
@@ -1064,11 +1065,12 @@ async def test_relative_link_construction():
             "type": "http",
             "scheme": "http",
             "method": "PUT",
-            "root_path": "http://test/stac",
+            "root_path": "/stac",  # root_path should not have proto, domain, or port
             "path": "/",
             "raw_path": b"/tab/abc",
             "query_string": b"",
             "headers": {},
+            "server": ("test", HTTP_PORT),
         }
     )
     links = CollectionLinks(collection_id="naip", request=req)

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -22,6 +22,7 @@ from stac_pydantic.shared import MimeTypes
 
 from stac_fastapi.sqlalchemy import serializers
 from stac_fastapi.sqlalchemy.extensions.query import Operator
+from stac_fastapi.sqlalchemy.links import get_base_url_from_request
 from stac_fastapi.sqlalchemy.models import database
 from stac_fastapi.sqlalchemy.session import Session
 from stac_fastapi.sqlalchemy.tokens import PaginationTokenClient
@@ -62,7 +63,7 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
 
     def all_collections(self, **kwargs) -> Collections:
         """Read all collections from the database."""
-        base_url = str(kwargs["request"].base_url)
+        base_url = get_base_url_from_request(kwargs["request"])
         with self.session.reader.context_session() as session:
             collections = session.query(self.collection_table).all()
             serialized_collections = [
@@ -93,7 +94,7 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
 
     def get_collection(self, collection_id: str, **kwargs) -> Collection:
         """Get collection by id."""
-        base_url = str(kwargs["request"].base_url)
+        base_url = get_base_url_from_request(kwargs["request"])
         with self.session.reader.context_session() as session:
             collection = self._lookup_id(collection_id, self.collection_table, session)
             return self.collection_serializer.db_to_stac(collection, base_url)
@@ -102,7 +103,7 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
         self, collection_id: str, limit: int = 10, token: str = None, **kwargs
     ) -> ItemCollection:
         """Read an item collection from the database."""
-        base_url = str(kwargs["request"].base_url)
+        base_url = get_base_url_from_request(kwargs["request"])
         with self.session.reader.context_session() as session:
             collection_children = (
                 session.query(self.item_table)
@@ -136,7 +137,7 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                     {
                         "rel": Relations.next.value,
                         "type": "application/geo+json",
-                        "href": f"{kwargs['request'].base_url}collections/{collection_id}/items?token={page.next}&limit={limit}",
+                        "href": f"{base_url}collections/{collection_id}/items?token={page.next}&limit={limit}",
                         "method": "GET",
                     }
                 )
@@ -145,7 +146,7 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                     {
                         "rel": Relations.previous.value,
                         "type": "application/geo+json",
-                        "href": f"{kwargs['request'].base_url}collections/{collection_id}/items?token={page.previous}&limit={limit}",
+                        "href": f"{base_url}collections/{collection_id}/items?token={page.previous}&limit={limit}",
                         "method": "GET",
                     }
                 )
@@ -173,7 +174,7 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
 
     def get_item(self, item_id: str, collection_id: str, **kwargs) -> Item:
         """Get item by id."""
-        base_url = str(kwargs["request"].base_url)
+        base_url = get_base_url_from_request(kwargs["request"])
         with self.session.reader.context_session() as session:
             db_query = session.query(self.item_table)
             db_query = db_query.filter(self.item_table.collection_id == collection_id)
@@ -262,7 +263,7 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
         self, search_request: BaseSearchPostRequest, **kwargs
     ) -> ItemCollection:
         """POST search catalog."""
-        base_url = str(kwargs["request"].base_url)
+        base_url = get_base_url_from_request(kwargs["request"])
         with self.session.reader.context_session() as session:
             token = (
                 self.get_token(search_request.token) if search_request.token else False
@@ -394,7 +395,7 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                     {
                         "rel": Relations.next.value,
                         "type": "application/geo+json",
-                        "href": f"{kwargs['request'].base_url}search",
+                        "href": f"{base_url}search",
                         "method": "POST",
                         "body": {"token": page.next},
                         "merge": True,
@@ -405,7 +406,7 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                     {
                         "rel": Relations.previous.value,
                         "type": "application/geo+json",
-                        "href": f"{kwargs['request'].base_url}search",
+                        "href": f"{base_url}search",
                         "method": "POST",
                         "body": {"token": page.previous},
                         "merge": True,

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/links.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/links.py
@@ -49,14 +49,7 @@ def get_base_url_from_request(request: Request) -> str:
         r"([^/])$",
         r"\1/",
         urljoin(
-            "".join(
-                [
-                    proto,
-                    "://",
-                    domain,
-                    port_suffix,
-                ]
-            ),
+            f"{proto}://{domain}{port_suffix}",
             # ensure root path starts with slash
             re.sub(r"^([^/])", r"/\1", request.scope.get("root_path")),
         ),

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/links.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/links.py
@@ -1,0 +1,64 @@
+"""Functionality to assist link construction."""
+
+import re
+from http.client import HTTP_PORT, HTTPS_PORT
+from urllib.parse import urljoin
+
+from starlette.requests import Request
+
+
+def get_base_url_from_request(request: Request) -> str:
+    """
+    Account for forwarding headers when deriving base URL.
+
+    Prioritise standard Forwarded header, look for non-standard X-Forwarded-* if missing.
+    Default to what can be derived from the URL if no headers provided.
+    """
+    if not isinstance(request, Request):
+        # Lots of tests execute setup logic with MockStarletteRequest
+        # and this type only has a single property: base_url.
+        return request.base_url
+    domain = request.url.hostname
+    proto = request.url.scheme
+    port_str = str(request.url.port) if request.url.port is not None else None
+    forwarded = request.headers.get("forwarded")
+    if forwarded is not None:
+        parts = forwarded.split(";")
+        for part in parts:
+            if len(part) > 0 and re.search("=", part):
+                key, value = part.split("=")
+                if key == "proto":
+                    proto = value
+                elif key == "host":
+                    host_parts = value.split(":")
+                    domain = host_parts[0]
+                    port_str = host_parts[1] if len(host_parts) == 2 else None
+    else:
+        proto = request.headers.get("x-forwarded-proto", proto)
+        port_str = request.headers.get("x-forwarded-port", port_str)
+    port_suffix = ""
+    if port_str is not None and port_str.isdigit():
+        if (proto == "http" and port_str == str(HTTP_PORT)) or (
+            proto == "https" and port_str == str(HTTPS_PORT)
+        ):
+            pass
+        else:
+            port_suffix = f":{port_str}"
+    # ensure url ends with slash
+    url = re.sub(
+        r"([^/])$",
+        r"\1/",
+        urljoin(
+            "".join(
+                [
+                    proto,
+                    "://",
+                    domain,
+                    port_suffix,
+                ]
+            ),
+            # ensure root path starts with slash
+            re.sub(r"^([^/])", r"/\1", request.scope.get("root_path")),
+        ),
+    )
+    return url

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/transactions.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/transactions.py
@@ -10,6 +10,7 @@ from stac_fastapi.extensions.third_party.bulk_transactions import (
     Items,
 )
 from stac_fastapi.sqlalchemy import serializers
+from stac_fastapi.sqlalchemy.links import get_base_url_from_request
 from stac_fastapi.sqlalchemy.models import database
 from stac_fastapi.sqlalchemy.session import Session
 from stac_fastapi.types import stac as stac_types
@@ -35,7 +36,7 @@ class TransactionsClient(BaseTransactionsClient):
 
     def create_item(self, model: stac_types.Item, **kwargs) -> stac_types.Item:
         """Create item."""
-        base_url = str(kwargs["request"].base_url)
+        base_url = get_base_url_from_request(kwargs["request"])
         data = self.item_serializer.stac_to_db(model)
         with self.session.writer.context_session() as session:
             session.add(data)
@@ -45,7 +46,7 @@ class TransactionsClient(BaseTransactionsClient):
         self, model: stac_types.Collection, **kwargs
     ) -> stac_types.Collection:
         """Create collection."""
-        base_url = str(kwargs["request"].base_url)
+        base_url = get_base_url_from_request(kwargs["request"])
         data = self.collection_serializer.stac_to_db(model)
         with self.session.writer.context_session() as session:
             session.add(data)
@@ -53,7 +54,7 @@ class TransactionsClient(BaseTransactionsClient):
 
     def update_item(self, model: stac_types.Item, **kwargs) -> stac_types.Item:
         """Update item."""
-        base_url = str(kwargs["request"].base_url)
+        base_url = get_base_url_from_request(kwargs["request"])
         with self.session.reader.context_session() as session:
             query = session.query(self.item_table).filter(
                 self.item_table.id == model["id"]
@@ -74,7 +75,7 @@ class TransactionsClient(BaseTransactionsClient):
         self, model: stac_types.Collection, **kwargs
     ) -> stac_types.Collection:
         """Update collection."""
-        base_url = str(kwargs["request"].base_url)
+        base_url = get_base_url_from_request(kwargs["request"])
         with self.session.reader.context_session() as session:
             query = session.query(self.collection_table).filter(
                 self.collection_table.id == model["id"]
@@ -92,7 +93,7 @@ class TransactionsClient(BaseTransactionsClient):
         self, item_id: str, collection_id: str, **kwargs
     ) -> stac_types.Item:
         """Delete item."""
-        base_url = str(kwargs["request"].base_url)
+        base_url = get_base_url_from_request(kwargs["request"])
         with self.session.writer.context_session() as session:
             query = session.query(self.item_table).filter(
                 self.item_table.collection_id == collection_id
@@ -108,7 +109,7 @@ class TransactionsClient(BaseTransactionsClient):
 
     def delete_collection(self, collection_id: str, **kwargs) -> stac_types.Collection:
         """Delete collection."""
-        base_url = str(kwargs["request"].base_url)
+        base_url = get_base_url_from_request(kwargs["request"])
         with self.session.writer.context_session() as session:
             query = session.query(self.collection_table).filter(
                 self.collection_table.id == collection_id

--- a/stac_fastapi/sqlalchemy/tests/resources/test_item.py
+++ b/stac_fastapi/sqlalchemy/tests/resources/test_item.py
@@ -946,3 +946,43 @@ def test_search_datetime_validation_errors(app_client):
 
         resp = app_client.get("/search?datetime={}".format(dt))
         assert resp.status_code == 400
+
+
+def test_get_item_forwarded_header(app_client, load_test_data):
+    test_item = load_test_data("test_item.json")
+    app_client.post(f"/collections/{test_item['collection']}/items", json=test_item)
+    get_item = app_client.get(
+        f"/collections/{test_item['collection']}/items/{test_item['id']}",
+        headers={"Forwarded": "proto=https;host=testserver:1234"},
+    )
+    for link in get_item.json()["links"]:
+        assert link["href"].startswith("https://testserver:1234/")
+
+
+def test_get_item_x_forwarded_headers(app_client, load_test_data):
+    test_item = load_test_data("test_item.json")
+    app_client.post(f"/collections/{test_item['collection']}/items", json=test_item)
+    get_item = app_client.get(
+        f"/collections/{test_item['collection']}/items/{test_item['id']}",
+        headers={
+            "X-Forwarded-Port": "1234",
+            "X-Forwarded-Proto": "https",
+        },
+    )
+    for link in get_item.json()["links"]:
+        assert link["href"].startswith("https://testserver:1234/")
+
+
+def test_get_item_duplicate_forwarded_headers(app_client, load_test_data):
+    test_item = load_test_data("test_item.json")
+    app_client.post(f"/collections/{test_item['collection']}/items", json=test_item)
+    get_item = app_client.get(
+        f"/collections/{test_item['collection']}/items/{test_item['id']}",
+        headers={
+            "Forwarded": "proto=https;host=testserver:1234",
+            "X-Forwarded-Port": "4321",
+            "X-Forwarded-Proto": "http",
+        },
+    )
+    for link in get_item.json()["links"]:
+        assert link["href"].startswith("https://testserver:1234/")


### PR DESCRIPTION
**Related Issue(s):** #
#5 

**Description:**
both stac-fastapi pgstac and sqlalchemy applications are ignorant of `Forwarded` and `X-Forwarded-*` HTTP headers and construct all URLs relative to the URL via which the request was received. This is a problem for deployments behind a load balancer or other proxy as the URL to hit the public endpoint may differ from the URL of the request forwarded from the load balancer / proxy to stac-fastapi.

For example: `https://` is often switched to `http://` when a load balancer forwards a request if the load balancer manages the SSL certificate. As a result URLs in links returned by stac-fastapi will incorrectly specify the `http` protocol. This might not be a big problem, as the load balancer may redirect requests to `http://` to `https://` via a 301 or 302 response, but not all clients can follow or are configured to follow 301 / 302 redirects. This has been observed causing problems in titiler when talking to stac-fastapi behind a load balancer.

FastAPI supports a [`root_path`](https://fastapi.tiangolo.com/advanced/behind-a-proxy/) parameter to address a problem that is similar but different. `root_path` is appended by FastAPI to `f"{protocol}://{domain}[:{port}]/"` and therefore cannot be used to change protocol or port in URLs.

**Note**: the repo contains two separate applications: pgstac and sqlalchemy, and across these applications there is duplication of both code and concepts. Each application has its own method of generating links (no idea why this logic wasn't shared) and therefore each has a copy of the `get_base_url_from_request` function here. This explains why this PR has duplicate code and does not follow a more sensible DRY strategy - the repo really isn't set up for it and I am not looking to make large-scale refactoring changes here.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).